### PR TITLE
Documentation shell missmatch.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: minimal
 
 script:
+  - export DL_DIR=$HOME/downloads # Export the path where to store downloaded files
+  - sh -c "$(curl -fsSkL https://raw.githubusercontent.com/openmeeg/ci-utils/master/travis/travis_tools.sh)"
 
 after_success:
 

--- a/README.md
+++ b/README.md
@@ -22,3 +22,5 @@ Todo
 
 -[ ] Add tests to the scripts
 -[ ] Add usage examples
+
+<!-- trigger travis -->


### PR DESCRIPTION
There's a mismatch between the scripting shell and the execution shell. 
It is written for `bash` and executed in `sh` makes the documentation false.